### PR TITLE
Corona: Add a RequestGuard class for basic request validation

### DIFF
--- a/src/Lunr/Corona/Parsers/ApiVersion/Tests/Helpers/MockApiVersionEnum.php
+++ b/src/Lunr/Corona/Parsers/ApiVersion/Tests/Helpers/MockApiVersionEnum.php
@@ -26,6 +26,11 @@ enum MockApiVersionEnum: int implements ParsedEnumValueInterface, ApiVersionInte
     case MOCK_1 = 1;
 
     /**
+     * Mock value.
+     */
+    case MOCK_2 = 2;
+
+    /**
      * Map scalar to an enum instance or NULL.
      *
      * This could just be an alias for BackedEnum::tryFrom(), but allows for more flexibility when needed.

--- a/src/Lunr/Corona/RequestGuard.php
+++ b/src/Lunr/Corona/RequestGuard.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file contains the RequestGuard class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Framna Netherlands B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Corona;
+
+use BackedEnum;
+use Lunr\Corona\Exceptions\BadRequestException;
+use Lunr\Corona\Exceptions\PreconditionFailedException;
+use Lunr\Corona\Parsers\ApiVersion\ApiVersionInterface;
+use Lunr\Corona\Parsers\ApiVersion\ApiVersionValue;
+
+/**
+ * RequestGuard class.
+ */
+class RequestGuard
+{
+
+    /**
+     * Shared instance of the Request class.
+     * @var Request
+     */
+    protected readonly Request $request;
+
+    /**
+     * Constructor.
+     *
+     * @param Request $request Shared instance of the Request class
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Destructor.
+     */
+    public function __destruct()
+    {
+        //NO-OP
+    }
+
+    /**
+     * Check Requirements for a webservice request.
+     *
+     * @param BackedEnum&ApiVersionInterface $version The minimum required API version for the webservice.
+     *
+     * @return void
+     */
+    public function validateApiVersion(BackedEnum&ApiVersionInterface $version): void
+    {
+        /**
+         * @var (BackedEnum&ApiVersionInterface)|null $api
+         */
+        $api = $this->request->getAsEnum(ApiVersionValue::ApiVersion);
+
+        if ($api === NULL)
+        {
+            $e = new BadRequestException('No API version specified!');
+
+            $e->setData(ApiVersionValue::ApiVersion->value, NULL);
+
+            throw $e;
+        }
+
+        if (!$api->isAtLeast($version))
+        {
+            throw new PreconditionFailedException('API version is no longer supported!');
+        }
+    }
+
+}
+
+?>

--- a/src/Lunr/Corona/Tests/RequestGuardBaseTest.php
+++ b/src/Lunr/Corona/Tests/RequestGuardBaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file contains the RequestGuardBaseTest class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Framna Netherlands B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Corona\Tests;
+
+/**
+ * This class contains common setup routines, providers
+ * and shared attributes for testing the RequestGuard class.
+ *
+ * @covers Lunr\Corona\RequestGuard
+ */
+class RequestGuardBaseTest extends RequestGuardTestCase
+{
+
+    /**
+     * Test that the Request class is set correctly.
+     */
+    public function testRequestSetCorrectly(): void
+    {
+        $this->assertPropertySame('request', $this->request);
+    }
+
+}
+
+?>

--- a/src/Lunr/Corona/Tests/RequestGuardTestCase.php
+++ b/src/Lunr/Corona/Tests/RequestGuardTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file contains the RequestGuardTestCase class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Framna Netherlands B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Corona\Tests;
+
+use Lunr\Corona\Request;
+use Lunr\Corona\RequestGuard;
+use Lunr\Halo\LunrBaseTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * This class contains common setup routines, providers
+ * and shared attributes for testing the RequestGuard class.
+ *
+ * @covers Lunr\Corona\RequestGuard
+ */
+abstract class RequestGuardTestCase extends LunrBaseTestCase
+{
+
+    /**
+     * Mock instance of the Request class.
+     * @var Request&MockObject
+     */
+    protected Request&MockObject $request;
+
+    /**
+     * Instance of the tested class.
+     * @var RequestGuard
+     */
+    protected RequestGuard $class;
+
+    /**
+     * Testcase Constructor.
+     */
+    public function setUp(): void
+    {
+        $this->request = $this->getMockBuilder(Request::class)
+                              ->disableOriginalConstructor()
+                              ->getMock();
+
+        $this->class = new RequestGuard($this->request);
+
+        parent::baseSetUp($this->class);
+    }
+
+    /**
+     * Testcase Destructor.
+     */
+    public function tearDown(): void
+    {
+        unset($this->request);
+        unset($this->class);
+
+        parent::tearDown();
+    }
+
+}
+
+?>

--- a/src/Lunr/Corona/Tests/RequestGuardValidateApiVersionTest.php
+++ b/src/Lunr/Corona/Tests/RequestGuardValidateApiVersionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file contains the RequestGuardValidateApiVersionTest class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Framna Netherlands B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Corona\Tests;
+
+use Lunr\Corona\Exceptions\BadRequestException;
+use Lunr\Corona\Exceptions\PreconditionFailedException;
+use Lunr\Corona\Parsers\ApiVersion\ApiVersionValue;
+use Lunr\Corona\Parsers\ApiVersion\Tests\Helpers\MockApiVersionEnum;
+
+/**
+ * This class contains tests for the RequestGuard class
+ *
+ * @covers Lunr\Corona\RequestGuard
+ */
+class RequestGuardValidateApiVersionTest extends RequestGuardTestCase
+{
+
+    /**
+     * Test that validateApiVersion() throws an exception when there is no api version.
+     *
+     * @covers Lunr\Corona\RequestGuard::validateApiVersion
+     */
+    public function testApiVersionIsInvalidWhenVersionIsMissing(): void
+    {
+        $this->request->expects($this->once())
+                      ->method('getAsEnum')
+                      ->with(ApiVersionValue::ApiVersion)
+                      ->willReturn(NULL);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('No API version specified');
+
+        try
+        {
+            $this->class->validateApiVersion(MockApiVersionEnum::MOCK_1);
+        }
+        catch (BadRequestException $e)
+        {
+            $this->assertEquals(ApiVersionValue::ApiVersion->value, $e->getDataKey());
+            $this->assertNull($e->getDataValue());
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Test that validateApiVersion() throws an exception when the given api version is too low.
+     *
+     * @covers Lunr\Corona\RequestGuard::validateApiVersion
+     */
+    public function testApiVersionIsInvalidWhenVersionIsTooLow(): void
+    {
+        $this->request->expects($this->once())
+                      ->method('getAsEnum')
+                      ->with(ApiVersionValue::ApiVersion)
+                      ->willReturn(MockApiVersionEnum::MOCK_1);
+
+        $this->expectException(PreconditionFailedException::class);
+        $this->expectExceptionMessage('API version is no longer supported!');
+
+        $this->class->validateApiVersion(MockApiVersionEnum::MOCK_2);
+    }
+
+    /**
+     * Test that validateApiVersion() throws no exception if API version is valid.
+     *
+     * @covers Lunr\Corona\RequestGuard::validateApiVersion
+     */
+    public function testValidateApiVersionIfValid(): void
+    {
+        $this->request->expects($this->once())
+                      ->method('getAsEnum')
+                      ->with(ApiVersionValue::ApiVersion)
+                      ->willReturn(MockApiVersionEnum::MOCK_1);
+
+        $this->class->validateApiVersion(MockApiVersionEnum::MOCK_1);
+    }
+
+}
+
+?>


### PR DESCRIPTION
This class is meant for validation of prerequesites to executing the called request, like API versions, access control, etc.