### PR TITLE
Parsers: Fix lazy initialization of nullable request values

### DIFF
--- a/src/Lunr/Corona/Parsers/ApiVersion/ApiVersionCliParser.php
+++ b/src/Lunr/Corona/Parsers/ApiVersion/ApiVersionCliParser.php
@@ -32,6 +32,12 @@ class ApiVersionCliParser implements RequestEnumValueParserInterface
     protected readonly ?BackedEnum $apiVersion;
 
     /**
+     * Whether the apiVersion value has been initialized or not.
+     * @var true
+     */
+    protected readonly bool $apiVersionInitialized;
+
+    /**
      * Parser CLI argument AST.
      * @var CliParameters
      */
@@ -83,7 +89,7 @@ class ApiVersionCliParser implements RequestEnumValueParserInterface
     public function get(BackedEnum&RequestValueInterface $key): ?string
     {
         return match ($key) {
-            ApiVersionValue::ApiVersion => ($this->apiVersion ?? $this->parse())?->value,
+            ApiVersionValue::ApiVersion => (isset($this->apiVersionInitialized) ? $this->apiVersion : $this->parse())?->value,
             default                     => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -98,7 +104,7 @@ class ApiVersionCliParser implements RequestEnumValueParserInterface
     public function getAsEnum(BackedEnum&RequestEnumValueInterface $key): ?BackedEnum
     {
         return match ($key) {
-            ApiVersionValue::ApiVersion => $this->apiVersion ?? $this->parse(),
+            ApiVersionValue::ApiVersion => isset($this->apiVersionInitialized) ? $this->apiVersion : $this->parse(),
             default                     => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -118,6 +124,8 @@ class ApiVersionCliParser implements RequestEnumValueParserInterface
         }
 
         $this->apiVersion = call_user_func_array([ $this->enumName, 'tryFromRequestValue' ], [ $version ]);
+
+        $this->apiVersionInitialized = TRUE;
 
         return $this->apiVersion;
     }

--- a/src/Lunr/Corona/Parsers/ApiVersion/ApiVersionHttpHeaderParser.php
+++ b/src/Lunr/Corona/Parsers/ApiVersion/ApiVersionHttpHeaderParser.php
@@ -29,6 +29,12 @@ class ApiVersionHttpHeaderParser implements RequestEnumValueParserInterface
     protected readonly ?BackedEnum $apiVersion;
 
     /**
+     * Whether the apiVersion value has been initialized or not.
+     * @var true
+     */
+    protected readonly bool $apiVersionInitialized;
+
+    /**
      * The name of the HTTP header holding the API version info
      * @var string
      */
@@ -80,7 +86,7 @@ class ApiVersionHttpHeaderParser implements RequestEnumValueParserInterface
     public function get(BackedEnum&RequestValueInterface $key): ?string
     {
         return match ($key) {
-            ApiVersionValue::ApiVersion => ($this->apiVersion ?? $this->parse())?->value,
+            ApiVersionValue::ApiVersion => (isset($this->apiVersionInitialized) ? $this->apiVersion : $this->parse())?->value,
             default                     => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -95,7 +101,7 @@ class ApiVersionHttpHeaderParser implements RequestEnumValueParserInterface
     public function getAsEnum(BackedEnum&RequestEnumValueInterface $key): ?BackedEnum
     {
         return match ($key) {
-            ApiVersionValue::ApiVersion => $this->apiVersion ?? $this->parse(),
+            ApiVersionValue::ApiVersion => isset($this->apiVersionInitialized) ? $this->apiVersion : $this->parse(),
             default                     => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -115,6 +121,8 @@ class ApiVersionHttpHeaderParser implements RequestEnumValueParserInterface
         }
 
         $this->apiVersion = call_user_func_array([ $this->enumName, 'tryFromRequestValue' ], [ $version ]);
+
+        $this->apiVersionInitialized = TRUE;
 
         return $this->apiVersion;
     }

--- a/src/Lunr/Corona/Parsers/ApiVersion/Tests/ApiVersionCliParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/ApiVersion/Tests/ApiVersionCliParserGetTest.php
@@ -57,10 +57,26 @@ class ApiVersionCliParserGetTest extends ApiVersionCliParserTestCase
         $version = MockApiVersionEnum::MOCK_1;
 
         $this->setReflectionPropertyValue('apiVersion', $version);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
 
         $value = $this->class->get(ApiVersionValue::ApiVersion);
 
         $this->assertEquals($version->value, $value);
+    }
+
+    /**
+     * Test getting a parsed API version.
+     *
+     * @covers Lunr\Corona\Parsers\ApiVersion\ApiVersionCliParser::get
+     */
+    public function testGetParsedNullApiVersion()
+    {
+        $this->setReflectionPropertyValue('apiVersion', NULL);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
+
+        $value = $this->class->get(ApiVersionValue::ApiVersion);
+
+        $this->assertNull($value);
     }
 
     /**
@@ -106,10 +122,26 @@ class ApiVersionCliParserGetTest extends ApiVersionCliParserTestCase
         $version = MockApiVersionEnum::MOCK_1;
 
         $this->setReflectionPropertyValue('apiVersion', $version);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
 
         $value = $this->class->getAsEnum(ApiVersionValue::ApiVersion);
 
         $this->assertEquals($version, $value);
+    }
+
+    /**
+     * Test getting a parsed API version.
+     *
+     * @covers Lunr\Corona\Parsers\ApiVersion\ApiVersionCliParser::getAsEnum
+     */
+    public function testGetParsedNullApiVersionAsEnum()
+    {
+        $this->setReflectionPropertyValue('apiVersion', NULL);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
+
+        $value = $this->class->getAsEnum(ApiVersionValue::ApiVersion);
+
+        $this->assertNull($value);
     }
 
     /**

--- a/src/Lunr/Corona/Parsers/ApiVersion/Tests/ApiVersionHttpHeaderParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/ApiVersion/Tests/ApiVersionHttpHeaderParserGetTest.php
@@ -57,10 +57,26 @@ class ApiVersionHttpHeaderParserGetTest extends ApiVersionHttpHeaderParserTestCa
         $version = MockApiVersionEnum::MOCK_1;
 
         $this->setReflectionPropertyValue('apiVersion', $version);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
 
         $value = $this->class->get(ApiVersionValue::ApiVersion);
 
         $this->assertEquals($version->value, $value);
+    }
+
+    /**
+     * Test getting a parsed API version.
+     *
+     * @covers Lunr\Corona\Parsers\ApiVersion\ApiVersionHttpHeaderParser::get
+     */
+    public function testGetParsedNullApiVersion()
+    {
+        $this->setReflectionPropertyValue('apiVersion', NULL);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
+
+        $value = $this->class->get(ApiVersionValue::ApiVersion);
+
+        $this->assertNull($value);
     }
 
     /**
@@ -121,10 +137,26 @@ class ApiVersionHttpHeaderParserGetTest extends ApiVersionHttpHeaderParserTestCa
         $version = MockApiVersionEnum::MOCK_1;
 
         $this->setReflectionPropertyValue('apiVersion', $version);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
 
         $value = $this->class->getAsEnum(ApiVersionValue::ApiVersion);
 
         $this->assertEquals($version, $value);
+    }
+
+    /**
+     * Test getting a parsed API version.
+     *
+     * @covers Lunr\Corona\Parsers\ApiVersion\ApiVersionHttpHeaderParser::getAsEnum
+     */
+    public function testGetParsedNullApiVersionAsEnum()
+    {
+        $this->setReflectionPropertyValue('apiVersion', NULL);
+        $this->setReflectionPropertyValue('apiVersionInitialized', TRUE);
+
+        $value = $this->class->getAsEnum(ApiVersionValue::ApiVersion);
+
+        $this->assertNull($value);
     }
 
     /**

--- a/src/Lunr/Corona/Parsers/BearerToken/BearerTokenCliParser.php
+++ b/src/Lunr/Corona/Parsers/BearerToken/BearerTokenCliParser.php
@@ -36,6 +36,12 @@ class BearerTokenCliParser implements RequestValueParserInterface
     protected readonly ?string $bearerToken;
 
     /**
+     * Whether the bearerToken value has been initialized or not.
+     * @var true
+     */
+    protected readonly bool $bearerTokenInitialized;
+
+    /**
      * Constructor.
      *
      * @param CliParameters $params Parsed CLI argument AST
@@ -73,7 +79,7 @@ class BearerTokenCliParser implements RequestValueParserInterface
     public function get(BackedEnum&RequestValueInterface $key): ?string
     {
         return match ($key) {
-            BearerTokenValue::BearerToken => $this->bearerToken ?? $this->parse(),
+            BearerTokenValue::BearerToken => isset($this->bearerTokenInitialized) ? $this->bearerToken : $this->parse(),
             default                       => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -93,6 +99,8 @@ class BearerTokenCliParser implements RequestValueParserInterface
         }
 
         $this->bearerToken = $token;
+
+        $this->bearerTokenInitialized = TRUE;
 
         return $token;
     }

--- a/src/Lunr/Corona/Parsers/BearerToken/BearerTokenParser.php
+++ b/src/Lunr/Corona/Parsers/BearerToken/BearerTokenParser.php
@@ -27,6 +27,12 @@ class BearerTokenParser implements RequestValueParserInterface
     protected readonly ?string $bearerToken;
 
     /**
+     * Whether the bearerToken value has been initialized or not.
+     * @var true
+     */
+    protected readonly bool $bearerTokenInitialized;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -62,7 +68,7 @@ class BearerTokenParser implements RequestValueParserInterface
     public function get(BackedEnum&RequestValueInterface $key): ?string
     {
         return match ($key) {
-            BearerTokenValue::BearerToken => $this->bearerToken ?? $this->parse(),
+            BearerTokenValue::BearerToken => isset($this->bearerTokenInitialized) ? $this->bearerToken : $this->parse(),
             default                       => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -86,6 +92,8 @@ class BearerTokenParser implements RequestValueParserInterface
         }
 
         $this->bearerToken = $token;
+
+        $this->bearerTokenInitialized = TRUE;
 
         return $token;
     }

--- a/src/Lunr/Corona/Parsers/BearerToken/Tests/BearerTokenCliParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/BearerToken/Tests/BearerTokenCliParserGetTest.php
@@ -55,10 +55,26 @@ class BearerTokenCliParserGetTest extends BearerTokenCliParserTestCase
         $token = '123456789';
 
         $this->setReflectionPropertyValue('bearerToken', $token);
+        $this->setReflectionPropertyValue('bearerTokenInitialized', TRUE);
 
         $value = $this->class->get(BearerTokenValue::BearerToken);
 
         $this->assertEquals($token, $value);
+    }
+
+    /**
+     * Test getting a parsed bearer token.
+     *
+     * @covers Lunr\Corona\Parsers\BearerToken\BearerTokenCliParser::get
+     */
+    public function testGetParsedNullBearerToken()
+    {
+        $this->setReflectionPropertyValue('bearerToken', NULL);
+        $this->setReflectionPropertyValue('bearerTokenInitialized', TRUE);
+
+        $value = $this->class->get(BearerTokenValue::BearerToken);
+
+        $this->assertNull($value);
     }
 
     /**

--- a/src/Lunr/Corona/Parsers/BearerToken/Tests/BearerTokenParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/BearerToken/Tests/BearerTokenParserGetTest.php
@@ -55,10 +55,26 @@ class BearerTokenParserGetTest extends BearerTokenParserTestCase
         $token = '123456789';
 
         $this->setReflectionPropertyValue('bearerToken', $token);
+        $this->setReflectionPropertyValue('bearerTokenInitialized', TRUE);
 
         $value = $this->class->get(BearerTokenValue::BearerToken);
 
         $this->assertEquals($token, $value);
+    }
+
+    /**
+     * Test getting a parsed bearer token.
+     *
+     * @covers Lunr\Corona\Parsers\BearerToken\BearerTokenParser::get
+     */
+    public function testGetParsedNullBearerToken()
+    {
+        $this->setReflectionPropertyValue('bearerToken', NULL);
+        $this->setReflectionPropertyValue('bearerTokenInitialized', TRUE);
+
+        $value = $this->class->get(BearerTokenValue::BearerToken);
+
+        $this->assertNull($value);
     }
 
     /**

--- a/src/Lunr/Corona/Parsers/Client/ClientApiKeyParser.php
+++ b/src/Lunr/Corona/Parsers/Client/ClientApiKeyParser.php
@@ -32,6 +32,12 @@ class ClientApiKeyParser implements RequestEnumValueParserInterface
     protected readonly ?BackedEnum $client;
 
     /**
+     * Whether the client value has been initialized or not.
+     * @var true
+     */
+    protected readonly bool $clientInitialized;
+
+    /**
      * The allowed API keys.
      * @var ApiKeys
      */
@@ -91,7 +97,7 @@ class ClientApiKeyParser implements RequestEnumValueParserInterface
     public function get(BackedEnum&RequestValueInterface $key): ?string
     {
         return match ($key) {
-            ClientValue::Client => ($this->client ?? $this->parse())?->value,
+            ClientValue::Client => (isset($this->clientInitialized) ? $this->client : $this->parse())?->value,
             default             => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -106,7 +112,7 @@ class ClientApiKeyParser implements RequestEnumValueParserInterface
     public function getAsEnum(BackedEnum&RequestEnumValueInterface $key): ?BackedEnum
     {
         return match ($key) {
-            ClientValue::Client => $this->client ?? $this->parse(),
+            ClientValue::Client => isset($this->clientInitialized) ? $this->client : $this->parse(),
             default             => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -133,6 +139,8 @@ class ClientApiKeyParser implements RequestEnumValueParserInterface
         {
             $this->client = call_user_func_array([ $this->enumName, 'tryFromRequestValue' ], [ NULL ]);
         }
+
+        $this->clientInitialized = TRUE;
 
         return $this->client;
     }

--- a/src/Lunr/Corona/Parsers/Client/ClientCliParser.php
+++ b/src/Lunr/Corona/Parsers/Client/ClientCliParser.php
@@ -32,6 +32,12 @@ class ClientCliParser implements RequestEnumValueParserInterface
     protected readonly ?BackedEnum $client;
 
     /**
+     * Whether the client value has been initialized or not.
+     * @var true
+     */
+    protected readonly bool $clientInitialized;
+
+    /**
      * Parser CLI argument AST.
      * @var CliParameters
      */
@@ -83,7 +89,7 @@ class ClientCliParser implements RequestEnumValueParserInterface
     public function get(BackedEnum&RequestValueInterface $key): ?string
     {
         return match ($key) {
-            ClientValue::Client => ($this->client ?? $this->parse())?->value,
+            ClientValue::Client => (isset($this->clientInitialized) ? $this->client : $this->parse())?->value,
             default             => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -98,7 +104,7 @@ class ClientCliParser implements RequestEnumValueParserInterface
     public function getAsEnum(BackedEnum&RequestEnumValueInterface $key): ?BackedEnum
     {
         return match ($key) {
-            ClientValue::Client => $this->client ?? $this->parse(),
+            ClientValue::Client => isset($this->clientInitialized) ? $this->client : $this->parse(),
             default             => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
     }
@@ -118,6 +124,8 @@ class ClientCliParser implements RequestEnumValueParserInterface
         }
 
         $this->client = call_user_func_array([ $this->enumName, 'tryFromRequestValue' ], [ $client ]);
+
+        $this->clientInitialized = TRUE;
 
         return $this->client;
     }

--- a/src/Lunr/Corona/Parsers/Client/Tests/ClientApiKeyParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/Client/Tests/ClientApiKeyParserGetTest.php
@@ -58,10 +58,26 @@ class ClientApiKeyParserGetTest extends ClientApiKeyParserTestCase
         $version = MockClientEnum::CommandLine;
 
         $this->setReflectionPropertyValue('client', $version);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
 
         $value = $this->class->get(ClientValue::Client);
 
         $this->assertEquals($version->value, $value);
+    }
+
+    /**
+     * Test getting a parsed client.
+     *
+     * @covers Lunr\Corona\Parsers\Client\ClientApiKeyParser::get
+     */
+    public function testGetParsedNullClient()
+    {
+        $this->setReflectionPropertyValue('client', NULL);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
+
+        $value = $this->class->get(ClientValue::Client);
+
+        $this->assertNull($value);
     }
 
     /**
@@ -142,10 +158,26 @@ class ClientApiKeyParserGetTest extends ClientApiKeyParserTestCase
         $version = MockClientEnum::CommandLine;
 
         $this->setReflectionPropertyValue('client', $version);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
 
         $value = $this->class->getAsEnum(ClientValue::Client);
 
         $this->assertEquals($version, $value);
+    }
+
+    /**
+     * Test getting a parsed client.
+     *
+     * @covers Lunr\Corona\Parsers\Client\ClientApiKeyParser::getAsEnum
+     */
+    public function testGetParsedNullClientAsEnum()
+    {
+        $this->setReflectionPropertyValue('client', NULL);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
+
+        $value = $this->class->getAsEnum(ClientValue::Client);
+
+        $this->assertNull($value);
     }
 
     /**

--- a/src/Lunr/Corona/Parsers/Client/Tests/ClientCliParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/Client/Tests/ClientCliParserGetTest.php
@@ -57,10 +57,26 @@ class ClientCliParserGetTest extends ClientCliParserTestCase
         $client = MockClientEnum::CommandLine;
 
         $this->setReflectionPropertyValue('client', $client);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
 
         $value = $this->class->get(ClientValue::Client);
 
         $this->assertEquals($client->value, $value);
+    }
+
+    /**
+     * Test getting a parsed client.
+     *
+     * @covers Lunr\Corona\Parsers\Client\ClientCliParser::get
+     */
+    public function testGetParsedNullClient()
+    {
+        $this->setReflectionPropertyValue('client', NULL);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
+
+        $value = $this->class->get(ClientValue::Client);
+
+        $this->assertNull($value);
     }
 
     /**
@@ -106,10 +122,26 @@ class ClientCliParserGetTest extends ClientCliParserTestCase
         $client = MockClientEnum::CommandLine;
 
         $this->setReflectionPropertyValue('client', $client);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
 
         $value = $this->class->getAsEnum(ClientValue::Client);
 
         $this->assertEquals($client, $value);
+    }
+
+    /**
+     * Test getting a parsed client.
+     *
+     * @covers Lunr\Corona\Parsers\Client\ClientCliParser::getAsEnum
+     */
+    public function testGetParsedNullClientAsEnum()
+    {
+        $this->setReflectionPropertyValue('client', NULL);
+        $this->setReflectionPropertyValue('clientInitialized', TRUE);
+
+        $value = $this->class->getAsEnum(ClientValue::Client);
+
+        $this->assertNull($value);
     }
 
     /**


### PR DESCRIPTION
PHP doesn't have an easy way to check whether a readonly property has been initialized to `NULL`. There's multiple workarounds:

1) Reflection

You could use `ReflectionProperty::isInitialized()` to check whether the property has been set or not. This works, but comes with the drawback of needing Reflection, which adds a performance penalty on the code (however miniscule it might be).

This is also quite repetitive code, so we'd need to centralize it in an `isInitialized()` method of an abstract `RequestValueParser` class that all parsers that need it would extend from.

2) Alternative "not found" value

You could adopt a different value to indicate that a request value has not been found. None of the existing scalar types qualify, however, since they could conflict with legitimate usecases for those values, which leaves objects.

Such an object wouldn't hold any values, it would just be an empty shell.

This would also require to change semantics in the `Request` class to return such an object instead of `NULL` for "not found" cases, which introduces quite a compatibility break with the existing code, for seemingly no practical reason.

3) Track initialization state in an array

For parsers that parse a lot of request values (currently none exist, however), having one property per value to track the initialization state may be cumbersome, but feels like the easiest option to ensure correctness.

Array properties can't be fully readonly, meaning the initialization state could still be modified at any point.

4) One property per value to track initialization state

Which leaves the least ugly version of one property to track the initialization state per value. That property is defined to only be able to exist in a boolean state. It's either `TRUE` or `uninitialized`, which makes it easy and performant to work with, just annoying.