### PR TITLE
Parsers: use a full config path

### DIFF
--- a/src/Lunr/Corona/RequestParser.php
+++ b/src/Lunr/Corona/RequestParser.php
@@ -25,14 +25,14 @@ class RequestParser implements RequestParserInterface
      * Shared instance of the Configuration class.
      * @var Configuration
      */
-    protected $config;
+    protected readonly Configuration $config;
 
     /**
      * Constructor.
      *
      * @param Configuration $configuration Shared instance of the Configuration class
      */
-    public function __construct($configuration)
+    public function __construct(Configuration $configuration)
     {
         $this->config = $configuration;
     }
@@ -42,7 +42,7 @@ class RequestParser implements RequestParserInterface
      */
     public function __destruct()
     {
-        unset($this->config);
+        //NO-OP
     }
 
     /**
@@ -56,13 +56,13 @@ class RequestParser implements RequestParserInterface
 
         $request['host'] = gethostname();
 
-        $request['application_path'] = $this->config['default_application_path'];
+        $request['application_path'] = $this->config['application']['default_application_path'] ?? NULL;
 
         $request['action'] = HttpMethod::GET;
 
         // Preset with default values:
-        $request['controller'] = $this->config['default_controller'];
-        $request['method']     = $this->config['default_method'];
+        $request['controller'] = $this->config['application']['default_controller'] ?? NULL;
+        $request['method']     = $this->config['application']['default_method'] ?? NULL;
         $request['params']     = [];
 
         if (isset($request['controller'], $request['method']) === TRUE)

--- a/src/Lunr/Corona/Tests/Helpers/RequestParserDynamicRequestTestTrait.php
+++ b/src/Lunr/Corona/Tests/Helpers/RequestParserDynamicRequestTestTrait.php
@@ -98,7 +98,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider deviceUserAgentKeyProvider
      */
-    public function testRequestDeviceUserAgent($key): void
+    public function testRequestDeviceUserAgent(string $key): void
     {
         $this->prepare_request_test('HTTP', '80', TRUE, $key);
 
@@ -134,7 +134,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider controllerKeyNameProvider
      */
-    public function testRequestController($key): void
+    public function testRequestController(string $key): void
     {
         $this->controller = $key;
 
@@ -157,7 +157,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider methodKeyNameProvider
      */
-    public function testRequestMethod($key): void
+    public function testRequestMethod(string $key): void
     {
         $this->method = $key;
 
@@ -180,7 +180,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider paramsKeyNameProvider
      */
-    public function testRequestParams($key): void
+    public function testRequestParams(string $key): void
     {
         $this->params = $key;
 
@@ -257,7 +257,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider controllerKeyNameProvider
      */
-    public function testRequestControllerWithSlashes($key): void
+    public function testRequestControllerWithSlashes(string $key): void
     {
         $this->controller = $key;
 
@@ -280,7 +280,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider methodKeyNameProvider
      */
-    public function testRequestMethodWithSlashes($key): void
+    public function testRequestMethodWithSlashes(string $key): void
     {
         $this->method = $key;
 
@@ -303,7 +303,7 @@ trait RequestParserDynamicRequestTestTrait
      *
      * @dataProvider paramsKeyNameProvider
      */
-    public function testRequestParamsWithSlashes($key): void
+    public function testRequestParamsWithSlashes(string $key): void
     {
         $this->params = $key;
 

--- a/src/Lunr/Corona/Tests/Helpers/RequestParserStaticRequestTestTrait.php
+++ b/src/Lunr/Corona/Tests/Helpers/RequestParserStaticRequestTestTrait.php
@@ -10,6 +10,7 @@
 
 namespace Lunr\Corona\Tests\Helpers;
 
+use Lunr\Core\Configuration;
 use Lunr\Corona\HttpMethod;
 use Psr\Log\LogLevel;
 
@@ -23,21 +24,25 @@ trait RequestParserStaticRequestTestTrait
      * Parameter key name for the controller.
      * @var string
      */
-    protected $controller = 'controller';
+    protected string $controller = 'controller';
 
     /**
      * Parameter key name for the method.
      * @var string
      */
-    protected $method = 'method';
+    protected string $method = 'method';
 
     /**
      * Parameter key name for the parameters.
      * @var string
      */
-    protected $params = 'param';
+    protected string $params = 'param';
 
-    protected $mockedCalls = [];
+    /**
+     * List of mocked calls.
+     * @var array
+     */
+    protected array $mockedCalls = [];
 
     /**
      * Preparation work for the request tests.
@@ -108,9 +113,25 @@ trait RequestParserStaticRequestTestTrait
     {
         $this->prepare_request_test();
 
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
         $this->configuration->expects($this->atLeast(2))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(2))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 
@@ -160,9 +181,25 @@ trait RequestParserStaticRequestTestTrait
     {
         $this->prepare_request_test('HTTP', '80', TRUE);
 
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->exactly(3))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
         $this->configuration->expects($this->exactly(3))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(2))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 
@@ -181,9 +218,25 @@ trait RequestParserStaticRequestTestTrait
         $this->prepare_request_test('HTTP', '80');
         $this->prepare_request_data();
 
-        $this->configuration->expects($this->atLeast(2))
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->atLeast(0))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(0))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
+        $this->configuration->expects($this->atLeast(0))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(0))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 
@@ -202,9 +255,25 @@ trait RequestParserStaticRequestTestTrait
         $this->prepare_request_test('HTTP', '80');
         $this->prepare_request_data();
 
-        $this->configuration->expects($this->atLeast(2))
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->atLeast(0))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(0))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
+        $this->configuration->expects($this->atLeast(0))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(0))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 
@@ -240,9 +309,25 @@ trait RequestParserStaticRequestTestTrait
         $this->prepare_request_test('HTTP', '80');
         $this->prepare_request_data();
 
-        $this->configuration->expects($this->atLeast(2))
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->atLeast(0))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(0))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
+        $this->configuration->expects($this->atLeast(0))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(0))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 
@@ -262,9 +347,25 @@ trait RequestParserStaticRequestTestTrait
 
         unset($this->mockedCalls['default_controller']);
 
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
         $this->configuration->expects($this->atLeast(2))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(2))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 
@@ -284,9 +385,25 @@ trait RequestParserStaticRequestTestTrait
 
         unset($this->mockedCalls['default_method']);
 
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetGet')
+                          ->willReturnMap(array_values($this->mockedCalls));
+
+        $applicationConfig->expects($this->atLeast(2))
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
         $this->configuration->expects($this->atLeast(2))
                             ->method('offsetGet')
-                            ->willReturnMap(array_values($this->mockedCalls));
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->atLeast(2))
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         $request = $this->class->parse_request();
 

--- a/src/Lunr/Corona/Tests/RequestParserParseRequestTest.php
+++ b/src/Lunr/Corona/Tests/RequestParserParseRequestTest.php
@@ -24,12 +24,6 @@ class RequestParserParseRequestTest extends RequestParserTestCase
     use RequestParserStaticRequestTestTrait;
 
     /**
-     * Mocked calls to Configuration
-     * @var array
-     */
-    protected $mockedCalls = [];
-
-    /**
      * Preparation work for the request tests.
      *
      * @param string $protocol  Protocol name

--- a/src/Lunr/Corona/Tests/WebRequestParserParseRequestTest.php
+++ b/src/Lunr/Corona/Tests/WebRequestParserParseRequestTest.php
@@ -10,6 +10,7 @@
 
 namespace Lunr\Corona\Tests;
 
+use Lunr\Core\Configuration;
 use Lunr\Corona\HttpMethod;
 use Lunr\Corona\Tests\Helpers\RequestParserDynamicRequestTestTrait;
 
@@ -86,9 +87,25 @@ class WebRequestParserParseRequestTest extends WebRequestParserTestCase
             $map[] = [ 'default_method', 'default_method' ];
         }
 
+        $applicationConfig = $this->getMockBuilder(Configuration::class)->getMock();
+
+        $applicationConfig->expects($this->any())
+                          ->method('offsetGet')
+                          ->willReturnMap($map);
+
+        $applicationConfig->expects($this->any())
+                          ->method('offsetExists')
+                          ->willReturn(TRUE);
+
         $this->configuration->expects($this->any())
                             ->method('offsetGet')
-                            ->willReturnMap($map);
+                            ->with('application')
+                            ->willReturn($applicationConfig);
+
+        $this->configuration->expects($this->any())
+                            ->method('offsetExists')
+                            ->with('application')
+                            ->willReturn(TRUE);
 
         if ($override === FALSE)
         {

--- a/src/Lunr/Corona/WebRequestParser.php
+++ b/src/Lunr/Corona/WebRequestParser.php
@@ -26,19 +26,19 @@ class WebRequestParser implements RequestParserInterface
      * Shared instance of the Configuration class.
      * @var Configuration
      */
-    protected $config;
+    protected readonly Configuration $config;
 
     /**
      * Shared instance of the Header class.
      * @var Header
      */
-    protected $header;
+    protected readonly Header $header;
 
     /**
      * Whether the request was parsed already or not,
      * @var bool
      */
-    protected $requestParsed;
+    protected bool $requestParsed;
 
     /**
      * Constructor.
@@ -46,7 +46,7 @@ class WebRequestParser implements RequestParserInterface
      * @param Configuration $configuration Shared instance of the Configuration class
      * @param Header        $header        Shared instance of the Header class
      */
-    public function __construct($configuration, $header)
+    public function __construct(Configuration $configuration, Header $header)
     {
         $this->config        = $configuration;
         $this->header        = $header;
@@ -58,8 +58,6 @@ class WebRequestParser implements RequestParserInterface
      */
     public function __destruct()
     {
-        unset($this->config);
-        unset($this->header);
         unset($this->requestParsed);
     }
 
@@ -118,8 +116,8 @@ class WebRequestParser implements RequestParserInterface
         }
 
         // Preset with default values:
-        $request['controller'] = $this->config['default_controller'];
-        $request['method']     = $this->config['default_method'];
+        $request['controller'] = $this->config['application']['default_controller'] ?? NULL;
+        $request['method']     = $this->config['application']['default_method'] ?? NULL;
         $request['params']     = [];
         $request['call']       = NULL;
         $request['verbosity']  = LogLevel::WARNING;

--- a/src/Lunr/Shadow/CliRequestParser.php
+++ b/src/Lunr/Shadow/CliRequestParser.php
@@ -28,19 +28,19 @@ class CliRequestParser implements RequestParserInterface
      * Shared instance of the Configuration class.
      * @var Configuration
      */
-    protected $config;
+    protected readonly Configuration $config;
 
     /**
      * Shared instance of the Header class.
      * @var Header
      */
-    protected $header;
+    protected readonly Header $header;
 
     /**
      * "Abstract Syntax Tree" of the passed arguments on the command line
      * @var array
      */
-    protected $ast;
+    protected array $ast;
 
     /**
      * Constructor.
@@ -49,7 +49,7 @@ class CliRequestParser implements RequestParserInterface
      * @param CliParserInterface $parser        The CliParser of this request
      * @param Header             $header        Shared instance of the Header class
      */
-    public function __construct($configuration, $parser, $header)
+    public function __construct(Configuration $configuration, CliParserInterface $parser, Header $header)
     {
         $this->config = $configuration;
         $this->header = $header;
@@ -61,8 +61,6 @@ class CliRequestParser implements RequestParserInterface
      */
     public function __destruct()
     {
-        unset($this->config);
-        unset($this->header);
         unset($this->ast);
     }
 
@@ -82,8 +80,8 @@ class CliRequestParser implements RequestParserInterface
         $request['action'] = HttpMethod::GET;
 
         // Preset with default values:
-        $request['controller'] = $this->config['default_controller'];
-        $request['method']     = $this->config['default_method'];
+        $request['controller'] = $this->config['application']['default_controller'] ?? NULL;
+        $request['method']     = $this->config['application']['default_method'] ?? NULL;
         $request['params']     = [];
 
         $request['device_useragent'] = NULL;


### PR DESCRIPTION
Make the config it reads more descriptive