### PR TITLE
Set symfony-compatible route info as span specific tags

### DIFF
--- a/src/Lunr/Corona/Controller.php
+++ b/src/Lunr/Corona/Controller.php
@@ -11,6 +11,7 @@
 namespace Lunr\Corona;
 
 use Lunr\Corona\Exceptions\NotImplementedException;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 
 /**
  * Controller class
@@ -92,11 +93,11 @@ abstract class Controller
      */
     protected function setResult(int $code, ?string $message = NULL, ?int $info = NULL): void
     {
-        $this->response->setResultCode($this->request->call, $code);
+        $this->response->setResultCode($this->request->get(RouteInfoValue::Name), $code);
 
         if ($message !== NULL)
         {
-            $this->response->setResultMessage($this->request->call, $message);
+            $this->response->setResultMessage($this->request->get(RouteInfoValue::Name), $message);
         }
 
         if ($info === NULL)
@@ -104,7 +105,7 @@ abstract class Controller
             return;
         }
 
-        $this->response->setResultInfoCode($this->request->call, $info);
+        $this->response->setResultInfoCode($this->request->get(RouteInfoValue::Name), $info);
     }
 
 }

--- a/src/Lunr/Corona/FrontController.php
+++ b/src/Lunr/Corona/FrontController.php
@@ -10,6 +10,7 @@
 
 namespace Lunr\Corona;
 
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
@@ -277,6 +278,12 @@ class FrontController
         {
             return;
         }
+
+        $override[RouteInfoValue::Name->value]   = $this->request->controller . '.' . $this->request->method;
+        $override[RouteInfoValue::Target->value] = $controller::class . '::' . $this->request->method;
+        $override[RouteInfoValue::Group->value]  = $this->request->controller;
+
+        $this->request->addMockValues($override);
 
         $this->handler->handle_request($callable, $this->request->params);
     }

--- a/src/Lunr/Corona/Parsers/RouteInfo/RouteInfoParser.php
+++ b/src/Lunr/Corona/Parsers/RouteInfo/RouteInfoParser.php
@@ -44,7 +44,7 @@ class RouteInfoParser implements RequestValueParserInterface
      * @param string $defaultGroup Default route group
      * @param string $defaultName  Default route name
      */
-    public function __construct(string $defaultGroup = 'general', string $defaultName = '/general/pre-routing')
+    public function __construct(string $defaultGroup = 'general', string $defaultName = 'general.pre-routing')
     {
         $this->group = $defaultGroup;
         $this->name  = $defaultName;

--- a/src/Lunr/Corona/Parsers/RouteInfo/RouteInfoParser.php
+++ b/src/Lunr/Corona/Parsers/RouteInfo/RouteInfoParser.php
@@ -33,6 +33,12 @@ class RouteInfoParser implements RequestValueParserInterface
     protected readonly string $name;
 
     /**
+     * The fully-qualifified class name and method name that handles the route.
+     * @var string
+     */
+    protected readonly string $target;
+
+    /**
      * Constructor.
      *
      * @param string $defaultGroup Default route group
@@ -73,10 +79,23 @@ class RouteInfoParser implements RequestValueParserInterface
     {
         // Request ID is an alias for Trace ID
         return match ($key) {
-            RouteInfoValue::Group => $this->group,
-            RouteInfoValue::Name  => $this->name,
+            RouteInfoValue::Group  => $this->group,
+            RouteInfoValue::Name   => $this->name,
+            RouteInfoValue::Target => $this->target ?? $this->parseTarget(),
             default               => throw new RuntimeException('Unsupported request value type "' . $key::class . '"'),
         };
+    }
+
+    /**
+     * Parse the target.
+     *
+     * @return string|null The parsed target
+     */
+    protected function parseTarget(): ?string
+    {
+        $this->target = basename($_SERVER['SCRIPT_NAME'] ?? 'unknown');
+
+        return $this->target;
     }
 
 }

--- a/src/Lunr/Corona/Parsers/RouteInfo/RouteInfoValue.php
+++ b/src/Lunr/Corona/Parsers/RouteInfo/RouteInfoValue.php
@@ -28,6 +28,12 @@ enum RouteInfoValue: string implements RequestValueInterface
      */
     case Name = 'name';
 
+    /**
+     * The fully-qualifified class name and method name that handles the route.
+     * Pre-routing this would be the filename of the entrypoint.
+     */
+    case Target = 'target';
+
 }
 
 ?>

--- a/src/Lunr/Corona/Parsers/RouteInfo/Tests/RouteInfoParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/RouteInfo/Tests/RouteInfoParserGetTest.php
@@ -17,7 +17,8 @@ use RuntimeException;
 /**
  * This class contains test methods for the RouteInfoParser class.
  *
- * @covers Lunr\Corona\Parsers\RouteInfo\RouteInfoParser
+ * @backupGlobals enabled
+ * @covers        Lunr\Corona\Parsers\RouteInfo\RouteInfoParser
  */
 class RouteInfoParserGetTest extends RouteInfoParserTestCase
 {
@@ -99,6 +100,60 @@ class RouteInfoParserGetTest extends RouteInfoParserTestCase
         $value = $nullValue->get(RouteInfoValue::Name);
 
         $this->assertEquals('/custom/api', $value);
+    }
+
+    /**
+     * Test getting the target.
+     *
+     * @covers Lunr\Corona\Parsers\RouteInfo\RouteInfoParser::get
+     */
+    public function testGetUnknownTarget(): void
+    {
+        unset($_SERVER['SCRIPT_NAME']);
+
+        $string = 'unknown';
+
+        $value = $this->class->get(RouteInfoValue::Target);
+
+        $this->assertEquals($string, $value);
+    }
+
+    /**
+     * Test getting the target.
+     *
+     * @covers Lunr\Corona\Parsers\RouteInfo\RouteInfoParser::get
+     */
+    public function testGetEntrypointTarget(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/app/index.php';
+
+        $string = 'index.php';
+
+        $value = $this->class->get(RouteInfoValue::Target);
+
+        $this->assertEquals($string, $value);
+    }
+
+    /**
+     * Test getting the target.
+     *
+     * @covers Lunr\Corona\Parsers\RouteInfo\RouteInfoParser::get
+     */
+    public function testGetParsedEntrypointTarget(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/app/index.php';
+
+        $string = 'index.php';
+
+        $value = $this->class->get(RouteInfoValue::Target);
+
+        $this->assertEquals($string, $value);
+
+        $_SERVER['SCRIPT_NAME'] = '/app/cli.php';
+
+        $value = $this->class->get(RouteInfoValue::Target);
+
+        $this->assertEquals($string, $value);
     }
 
 }

--- a/src/Lunr/Corona/Parsers/RouteInfo/Tests/RouteInfoParserGetTest.php
+++ b/src/Lunr/Corona/Parsers/RouteInfo/Tests/RouteInfoParserGetTest.php
@@ -81,7 +81,7 @@ class RouteInfoParserGetTest extends RouteInfoParserTestCase
      */
     public function testGetDefaultName(): void
     {
-        $string = '/general/pre-routing';
+        $string = 'general.pre-routing';
 
         $value = $this->class->get(RouteInfoValue::Name);
 

--- a/src/Lunr/Corona/Request.php
+++ b/src/Lunr/Corona/Request.php
@@ -11,6 +11,7 @@
 namespace Lunr\Corona;
 
 use BackedEnum;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 use Lunr\Corona\Parsers\TracingInfo\TracingInfoValue;
 use Lunr\Ticks\EventLogging\EventInterface;
 use Lunr\Ticks\TracingControllerInterface;
@@ -254,10 +255,15 @@ class Request implements TracingControllerInterface, TracingInfoInterface
      */
     public function getSpanSpecificTags(): array
     {
+        if (!isset($this->parsers[RouteInfoValue::class]))
+        {
+            return [];
+        }
+
         return [
-            'controller' => $this->controller,
-            'method'     => $this->method,
-            'call'       => $this->call,
+            'controller' => $this->get(RouteInfoValue::Target),
+            'route'      => $this->get(RouteInfoValue::Name),
+            'routeGroup' => $this->get(RouteInfoValue::Group),
         ];
     }
 

--- a/src/Lunr/Corona/RequestParser.php
+++ b/src/Lunr/Corona/RequestParser.php
@@ -67,7 +67,7 @@ class RequestParser implements RequestParserInterface
 
         if (isset($request['controller'], $request['method']) === TRUE)
         {
-            $request['call'] = $request['controller'] . '/' . $request['method'];
+            $request['call'] = $request['controller'] . '.' . $request['method'];
         }
         else
         {

--- a/src/Lunr/Corona/RequestResultHandler.php
+++ b/src/Lunr/Corona/RequestResultHandler.php
@@ -14,6 +14,7 @@ namespace Lunr\Corona;
 use BackedEnum;
 use Lunr\Corona\Exceptions\ClientDataHttpException;
 use Lunr\Corona\Exceptions\HttpException;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 use Lunr\Ticks\EventLogging\EventLoggerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -168,11 +169,11 @@ class RequestResultHandler
      */
     private function setResult(int $code, ?string $message = NULL, ?int $info = NULL): void
     {
-        $this->response->setResultCode($this->request->call, $code);
+        $this->response->setResultCode($this->request->get(RouteInfoValue::Name), $code);
 
         if ($message !== NULL)
         {
-            $this->response->setResultMessage($this->request->call, $message);
+            $this->response->setResultMessage($this->request->get(RouteInfoValue::Name), $message);
         }
 
         if ($info === NULL)
@@ -180,7 +181,7 @@ class RequestResultHandler
             return;
         }
 
-        $this->response->setResultInfoCode($this->request->call, $info);
+        $this->response->setResultInfoCode($this->request->get(RouteInfoValue::Name), $info);
     }
 
     /**

--- a/src/Lunr/Corona/Tests/ControllerResultTest.php
+++ b/src/Lunr/Corona/Tests/ControllerResultTest.php
@@ -12,6 +12,7 @@ namespace Lunr\Corona\Tests;
 
 use Lunr\Corona\Exceptions\NotImplementedException;
 use Lunr\Corona\HttpCode;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 
 /**
  * This class contains test methods for the Controller class.
@@ -42,13 +43,13 @@ class ControllerResultTest extends ControllerTestCase
     public function testSetResultReturnCode(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $method = $this->getReflectionMethod('setResult');
 
@@ -63,13 +64,13 @@ class ControllerResultTest extends ControllerTestCase
     public function testSetResultErrorMessageNull(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->never())
                        ->method('setResultMessage');
@@ -87,17 +88,17 @@ class ControllerResultTest extends ControllerTestCase
     public function testSetResultErrorMessage(): void
     {
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', 'errmsg');
+                       ->with('controller.method', 'errmsg');
 
         $method = $this->getReflectionMethod('setResult');
 
@@ -112,13 +113,13 @@ class ControllerResultTest extends ControllerTestCase
     public function testSetResultErrorInfoNull(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->never())
                        ->method('setResultInfoCode');
@@ -136,17 +137,17 @@ class ControllerResultTest extends ControllerTestCase
     public function testSetResultErrorInfoNotNull(): void
     {
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->once())
                        ->method('setResultInfoCode')
-                       ->with('controller/method', 2060);
+                       ->with('controller.method', 2060);
 
         $method = $this->getReflectionMethod('setResult');
 
@@ -161,13 +162,13 @@ class ControllerResultTest extends ControllerTestCase
     public function testDeprecatedSetResultReturnCode(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $method = $this->getReflectionMethod('set_result');
 
@@ -182,13 +183,13 @@ class ControllerResultTest extends ControllerTestCase
     public function testDeprecatedSetResultErrorMessageNull(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->never())
                        ->method('setResultMessage');
@@ -206,17 +207,17 @@ class ControllerResultTest extends ControllerTestCase
     public function testDeprecatedSetResultErrorMessage(): void
     {
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', 'errmsg');
+                       ->with('controller.method', 'errmsg');
 
         $method = $this->getReflectionMethod('set_result');
 
@@ -231,13 +232,13 @@ class ControllerResultTest extends ControllerTestCase
     public function testDeprecatedSetResultErrorInfoNull(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->never())
                        ->method('setResultInfoCode');
@@ -255,17 +256,17 @@ class ControllerResultTest extends ControllerTestCase
     public function testDeprecatedSetResultErrorInfoNotNull(): void
     {
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::PARTIAL_CONTENT);
+                       ->with('controller.method', HttpCode::PARTIAL_CONTENT);
 
         $this->response->expects($this->once())
                        ->method('setResultInfoCode')
-                       ->with('controller/method', 2060);
+                       ->with('controller.method', 2060);
 
         $method = $this->getReflectionMethod('set_result');
 

--- a/src/Lunr/Corona/Tests/FrontControllerDispatchTest.php
+++ b/src/Lunr/Corona/Tests/FrontControllerDispatchTest.php
@@ -33,12 +33,23 @@ class FrontControllerDispatchTest extends FrontControllerTestCase
                       ->method('handle_request')
                       ->with([ $controller, 'foo' ], [ 1, 2 ]);
 
-        $this->request->expects($this->exactly(2))
+        $this->request->expects($this->exactly(6))
                       ->method('__get')
                       ->willReturnMap([
+                          [ 'controller', 'baz' ],
                           [ 'method', 'foo' ],
                           [ 'params', [ 1, 2 ]],
                       ]);
+
+        $mock = [
+            'name'   => 'baz.foo',
+            'target' => $controller::class . '::foo',
+            'group'  => 'baz',
+        ];
+
+        $this->request->expects($this->once())
+                      ->method('addMockValues')
+                      ->with($mock);
 
         $this->class->dispatch($controller);
     }

--- a/src/Lunr/Corona/Tests/Helpers/RequestParserDynamicRequestTestTrait.php
+++ b/src/Lunr/Corona/Tests/Helpers/RequestParserDynamicRequestTestTrait.php
@@ -211,7 +211,7 @@ trait RequestParserDynamicRequestTestTrait
 
         $this->assertIsArray($request);
         $this->assertArrayHasKey('call', $request);
-        $this->assertEquals('thecontroller/themethod', $request['call']);
+        $this->assertEquals('thecontroller.themethod', $request['call']);
 
         $this->cleanup_request_test();
     }
@@ -334,7 +334,7 @@ trait RequestParserDynamicRequestTestTrait
 
         $this->assertIsArray($request);
         $this->assertArrayHasKey('call', $request);
-        $this->assertEquals('thecontroller/themethod', $request['call']);
+        $this->assertEquals('thecontroller.themethod', $request['call']);
 
         $this->cleanup_request_test();
     }

--- a/src/Lunr/Corona/Tests/Helpers/RequestParserStaticRequestTestTrait.php
+++ b/src/Lunr/Corona/Tests/Helpers/RequestParserStaticRequestTestTrait.php
@@ -248,7 +248,7 @@ trait RequestParserStaticRequestTestTrait
 
         $this->assertIsArray($request);
         $this->assertArrayHasKey('call', $request);
-        $this->assertEquals('DefaultController/default_method', $request['call']);
+        $this->assertEquals('DefaultController.default_method', $request['call']);
 
         $this->cleanup_request_test();
     }

--- a/src/Lunr/Corona/Tests/RequestGetValueTest.php
+++ b/src/Lunr/Corona/Tests/RequestGetValueTest.php
@@ -9,6 +9,8 @@
 
 namespace Lunr\Corona\Tests;
 
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoParser;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 use Lunr\Corona\Parsers\TracingInfo\TracingInfoValue;
 use Lunr\Corona\RequestValueParserInterface;
 use Lunr\Corona\Tests\Helpers\MockRequestValue;
@@ -350,12 +352,46 @@ class RequestGetValueTest extends RequestTestCase
      *
      * @covers Lunr\Corona\Request::getSpanSpecificTags
      */
-    public function testGetSpanSpecificTags(): void
+    public function testGetSpanSpecificTagsWithoutRegisteredParser(): void
     {
+        $expected = [];
+
+        $value = $this->class->getSpanSpecificTags();
+
+        $this->assertEquals($expected, $value);
+    }
+
+    /**
+     * Test getSpanSpecificTags().
+     *
+     * @covers Lunr\Corona\Request::getSpanSpecificTags
+     */
+    public function testGetSpanSpecificTagsWithRegisteredParser(): void
+    {
+        $parser = $this->getMockBuilder(RouteInfoParser::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $parser->expects($this->once())
+               ->method('getRequestValueType')
+               ->willReturn(RouteInfoValue::class);
+
+        $parser->expects($this->exactly(3))
+               ->method('get')
+               ->willReturnMap(
+                   [
+                       [ RouteInfoValue::Name, 'foo.bar' ],
+                       [ RouteInfoValue::Group, 'foo' ],
+                       [ RouteInfoValue::Target, 'FooController::bar' ],
+                   ]
+               );
+
+        $this->class->registerParser($parser);
+
         $expected = [
-            'controller' => 'controller',
-            'method'     => 'method',
-            'call'       => 'controller/method',
+            'controller' => 'FooController::bar',
+            'route'      => 'foo.bar',
+            'routeGroup' => 'foo',
         ];
 
         $value = $this->class->getSpanSpecificTags();

--- a/src/Lunr/Corona/Tests/RequestResultHandlerHandleRequestTest.php
+++ b/src/Lunr/Corona/Tests/RequestResultHandlerHandleRequestTest.php
@@ -13,6 +13,7 @@ namespace Lunr\Corona\Tests;
 use Error;
 use Exception;
 use Lunr\Corona\Exceptions\BadRequestException;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 
 /**
  * This class contains test methods for the RequestResultHandler class.
@@ -33,10 +34,10 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                            ->disableOriginalConstructor()
                            ->getMock();
 
-        $this->request->expects($this->exactly(1))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+        $this->request->expects($this->once())
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -44,7 +45,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 200);
+                       ->with('controller.method', 200);
 
         $controller->expects($this->once())
                    ->method('foo')
@@ -62,10 +63,10 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
     {
         $controller = 'Lunr\Corona\Tests\MockController';
 
-        $this->request->expects($this->exactly(1))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+        $this->request->expects($this->once())
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -73,7 +74,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 200);
+                       ->with('controller.method', 200);
 
         $this->class->handleRequest([ $controller, 'bar' ], [ 1, 2 ]);
     }
@@ -94,13 +95,13 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                    ->will($this->throwException(new BadRequestException('Bad Request!')));
 
         $this->request->expects($this->exactly(3))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 400);
+                       ->with('controller.method', 400);
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -110,7 +111,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', $message);
+                       ->with('controller.method', $message);
 
         $this->class->handleRequest([ $controller, 'foo' ], []);
     }
@@ -133,13 +134,13 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                    ->will($this->throwException($exception));
 
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 500);
+                       ->with('controller.method', 500);
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -149,7 +150,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', $message);
+                       ->with('controller.method', $message);
 
         $this->logger->expects($this->once())
                      ->method('error')
@@ -176,13 +177,13 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                    ->will($this->throwException($exception));
 
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 500);
+                       ->with('controller.method', 500);
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -192,7 +193,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', $message);
+                       ->with('controller.method', $message);
 
         $this->logger->expects($this->once())
                      ->method('error')
@@ -215,10 +216,10 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
         $controller->expects($this->once())
                    ->method('foo');
 
-        $this->request->expects($this->exactly(1))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+        $this->request->expects($this->once())
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -226,7 +227,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 200);
+                       ->with('controller.method', 200);
 
         $this->response->expects($this->never())
                        ->method('setResultMessage');
@@ -245,10 +246,10 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                            ->disableOriginalConstructor()
                            ->getMock();
 
-        $this->request->expects($this->exactly(1))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+        $this->request->expects($this->once())
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -256,7 +257,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 200);
+                       ->with('controller.method', 200);
 
         $controller->expects($this->once())
                    ->method('foo')
@@ -274,10 +275,10 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
     {
         $controller = 'Lunr\Corona\Tests\MockController';
 
-        $this->request->expects($this->exactly(1))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+        $this->request->expects($this->once())
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -285,7 +286,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 200);
+                       ->with('controller.method', 200);
 
         $this->class->handle_request([ $controller, 'bar' ], [ 1, 2 ]);
     }
@@ -306,13 +307,13 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                    ->will($this->throwException(new BadRequestException('Bad Request!')));
 
         $this->request->expects($this->exactly(3))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 400);
+                       ->with('controller.method', 400);
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -322,7 +323,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', $message);
+                       ->with('controller.method', $message);
 
         $this->class->handle_request([ $controller, 'foo' ], []);
     }
@@ -345,13 +346,13 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                    ->will($this->throwException($exception));
 
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 500);
+                       ->with('controller.method', 500);
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -361,7 +362,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', $message);
+                       ->with('controller.method', $message);
 
         $this->logger->expects($this->once())
                      ->method('error')
@@ -388,13 +389,13 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
                    ->will($this->throwException($exception));
 
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 500);
+                       ->with('controller.method', 500);
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -404,7 +405,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', $message);
+                       ->with('controller.method', $message);
 
         $this->logger->expects($this->once())
                      ->method('error')
@@ -427,10 +428,10 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
         $controller->expects($this->once())
                    ->method('foo');
 
-        $this->request->expects($this->exactly(1))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+        $this->request->expects($this->once())
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->exactly(1))
                        ->method('hasCustomResultSet')
@@ -438,7 +439,7 @@ class RequestResultHandlerHandleRequestTest extends RequestResultHandlerTestCase
 
         $this->response->expects($this->exactly(1))
                        ->method('setResultCode')
-                       ->with('controller/method', 200);
+                       ->with('controller.method', 200);
 
         $this->response->expects($this->never())
                        ->method('setResultMessage');

--- a/src/Lunr/Corona/Tests/RequestResultHandlerLogRequestResultTest.php
+++ b/src/Lunr/Corona/Tests/RequestResultHandlerLogRequestResultTest.php
@@ -195,7 +195,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
 
         $this->request->expects($this->once())
                       ->method('getSpanSpecificTags')
-                      ->willReturn([ 'call' => 'controller/method' ]);
+                      ->willReturn([ 'name' => 'controller.method' ]);
 
         $this->eventLogger->expects($this->once())
                           ->method('newEvent')
@@ -217,7 +217,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
                     ->method('setParentSpanId');
 
         $tags = [
-            'call' => 'controller/method',
+            'name' => 'controller.method',
         ];
 
         $this->event->expects($this->once())
@@ -271,7 +271,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
 
         $this->request->expects($this->once())
                       ->method('getSpanSpecificTags')
-                      ->willReturn([ 'call' => 'controller/method' ]);
+                      ->willReturn([ 'name' => 'controller.method' ]);
 
         $this->eventLogger->expects($this->once())
                           ->method('newEvent')
@@ -294,7 +294,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
                     ->with($parentSpanID);
 
         $tags = [
-            'call' => 'controller/method',
+            'name' => 'controller.method',
         ];
 
         $this->event->expects($this->once())
@@ -348,7 +348,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
 
         $this->request->expects($this->once())
                       ->method('getSpanSpecificTags')
-                      ->willReturn([ 'call' => 'controller/method' ]);
+                      ->willReturn([ 'name' => 'controller.method' ]);
 
         $this->request->expects($this->once())
                       ->method('get')
@@ -376,7 +376,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
                     ->with($parentSpanID);
 
         $tags = [
-            'call'   => 'controller/method',
+            'name'   => 'controller.method',
             'client' => 'Command Line',
         ];
 
@@ -433,7 +433,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
 
         $this->request->expects($this->once())
                       ->method('getSpanSpecificTags')
-                      ->willReturn([ 'call' => 'controller/method' ]);
+                      ->willReturn([ 'name' => 'controller.method' ]);
 
         $this->eventLogger->expects($this->once())
                           ->method('newEvent')
@@ -455,7 +455,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
                     ->with($parentSpanID);
 
         $tags = [
-            'call'     => 'controller/method',
+            'name'     => 'controller.method',
             'inputKey' => 'input-key',
         ];
 
@@ -513,7 +513,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
 
         $this->request->expects($this->once())
                       ->method('getSpanSpecificTags')
-                      ->willReturn([ 'call' => 'controller/method' ]);
+                      ->willReturn([ 'name' => 'controller.method' ]);
 
         $this->eventLogger->expects($this->once())
                           ->method('newEvent')
@@ -535,7 +535,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
                     ->with($parentSpanID);
 
         $tags = [
-            'call' => 'controller/method',
+            'name' => 'controller.method',
         ];
 
         $this->event->expects($this->once())
@@ -592,7 +592,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
 
         $this->request->expects($this->once())
                       ->method('getSpanSpecificTags')
-                      ->willReturn([ 'call' => 'controller/method' ]);
+                      ->willReturn([ 'name' => 'controller.method' ]);
 
         $this->request->expects($this->once())
                       ->method('get')
@@ -619,7 +619,7 @@ class RequestResultHandlerLogRequestResultTest extends RequestResultHandlerTestC
                     ->with($parentSpanID);
 
         $tags = [
-            'call'     => 'controller/method',
+            'name'     => 'controller.method',
             'client'   => 'Command Line',
             'inputKey' => 'input-key',
         ];

--- a/src/Lunr/Corona/Tests/RequestResultHandlerSetResultTest.php
+++ b/src/Lunr/Corona/Tests/RequestResultHandlerSetResultTest.php
@@ -11,6 +11,7 @@
 namespace Lunr\Corona\Tests;
 
 use Lunr\Corona\HttpCode;
+use Lunr\Corona\Parsers\RouteInfo\RouteInfoValue;
 
 /**
  * This class contains test methods for the RequestResultHandler class.
@@ -28,13 +29,13 @@ class RequestResultHandlerSetResultTest extends RequestResultHandlerTestCase
     public function testSetResultReturnCode(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::NOT_IMPLEMENTED);
+                       ->with('controller.method', HttpCode::NOT_IMPLEMENTED);
 
         $method = $this->getReflectionMethod('setResult');
 
@@ -49,13 +50,13 @@ class RequestResultHandlerSetResultTest extends RequestResultHandlerTestCase
     public function testSetResultErrorMessageNull(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::NOT_IMPLEMENTED);
+                       ->with('controller.method', HttpCode::NOT_IMPLEMENTED);
 
         $this->response->expects($this->never())
                        ->method('setResultMessage');
@@ -73,17 +74,17 @@ class RequestResultHandlerSetResultTest extends RequestResultHandlerTestCase
     public function testSetResultErrorMessage(): void
     {
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::NOT_IMPLEMENTED);
+                       ->with('controller.method', HttpCode::NOT_IMPLEMENTED);
 
         $this->response->expects($this->once())
                        ->method('setResultMessage')
-                       ->with('controller/method', 'errmsg');
+                       ->with('controller.method', 'errmsg');
 
         $method = $this->getReflectionMethod('setResult');
 
@@ -98,13 +99,13 @@ class RequestResultHandlerSetResultTest extends RequestResultHandlerTestCase
     public function testSetResultErrorInfoNull(): void
     {
         $this->request->expects($this->once())
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::NOT_IMPLEMENTED);
+                       ->with('controller.method', HttpCode::NOT_IMPLEMENTED);
 
         $this->response->expects($this->never())
                        ->method('setResultInfoCode');
@@ -122,17 +123,17 @@ class RequestResultHandlerSetResultTest extends RequestResultHandlerTestCase
     public function testSetResultErrorInfoNotNull(): void
     {
         $this->request->expects($this->exactly(2))
-                      ->method('__get')
-                      ->with('call')
-                      ->willReturn('controller/method');
+                      ->method('get')
+                      ->with(RouteInfoValue::Name)
+                      ->willReturn('controller.method');
 
         $this->response->expects($this->once())
                        ->method('setResultCode')
-                       ->with('controller/method', HttpCode::NOT_IMPLEMENTED);
+                       ->with('controller.method', HttpCode::NOT_IMPLEMENTED);
 
         $this->response->expects($this->once())
                        ->method('setResultInfoCode')
-                       ->with('controller/method', 9999);
+                       ->with('controller.method', 9999);
 
         $method = $this->getReflectionMethod('setResult');
 

--- a/src/Lunr/Corona/WebRequestParser.php
+++ b/src/Lunr/Corona/WebRequestParser.php
@@ -128,7 +128,7 @@ class WebRequestParser implements RequestParserInterface
         {
             if (isset($request['controller'], $request['method']) === TRUE)
             {
-                $request['call'] = $request['controller'] . '/' . $request['method'];
+                $request['call'] = $request['controller'] . '.' . $request['method'];
             }
 
             $this->requestParsed = TRUE;
@@ -152,7 +152,7 @@ class WebRequestParser implements RequestParserInterface
 
         if (isset($request['controller'], $request['method']) === TRUE)
         {
-            $request['call'] = $request['controller'] . '/' . $request['method'];
+            $request['call'] = $request['controller'] . '.' . $request['method'];
         }
 
         $this->requestParsed = TRUE;

--- a/src/Lunr/Shadow/CliRequestParser.php
+++ b/src/Lunr/Shadow/CliRequestParser.php
@@ -129,7 +129,7 @@ class CliRequestParser implements RequestParserInterface
 
         if (isset($request['controller'], $request['method']) === TRUE)
         {
-            $request['call'] = $request['controller'] . '/' . $request['method'];
+            $request['call'] = $request['controller'] . '.' . $request['method'];
         }
         else
         {


### PR DESCRIPTION
https://github.com/symfony/monolog-bridge/blob/8.1/Processor/RouteProcessor.php can be used to attach the route info to logs in symfony, which sets the `controller` and `route` tags. I'm setting `group` here too, because *I* think it's useful, but there's no out-of-the-box equivalent in symfony (as far as I could find)